### PR TITLE
Added the option to change the length of the timeline

### DIFF
--- a/demo/main.js
+++ b/demo/main.js
@@ -1,6 +1,8 @@
 function generate() {
+  var timeline_start_hour = 8;
+  var timeline_end_hour = 20;
   var tasks = [];
-  for (var i = 0; i < 20; i++) {
+  for (var i = 0; i < 5; i++) {
     var startTime = -1;
     var duration = 0.5;
     for (var j = 0; j < 10; j++) {
@@ -24,15 +26,17 @@ function generate() {
 
       duration -= startTime + duration > 24 ? (startTime + duration) - 24 : 0;
 
-      var task = {
-        startTime: startTime,
-        duration: duration,
-        column: i,
-        id: Math.ceil(Math.random() * 100000),
-        title: 'Service ' + i + ' ' + j
-      };
-
-      tasks.push(task);
+      if(startTime>timeline_start_hour && (startTime+duration < timeline_end_hour)){
+        var task = {
+          startTime: startTime,
+          duration: duration,
+          column: i,
+          id: Math.ceil(Math.random() * 100000),
+          title: 'Service ' + j + ' by specialist ' + i
+        };
+  
+        tasks.push(task);
+      }
     }
   }
 
@@ -41,9 +45,11 @@ function generate() {
   console.log(JSON.stringify(tasks));
 
   $("#skeduler-container").skeduler({
-    headers: ["Specialist 1", "Specialist 2", "Specialist 3", "Specialist 4", "Specialist 5",  "Specialist 6", "Specialist 7", "Specialist 8", "Specialist 9", "Specialist 10"],
+    headers: ["Specialist 1", "Specialist 2", "Specialist 3", "Specialist 4", "Specialist 5"],
     tasks: tasks,
     cardTemplate: '<div>${id}</div><div>${title}</div>',
+    timelineStart: timeline_start_hour,
+    timelineStop: timeline_end_hour,
     onClick: function (e, t) { console.log(e, t); }
   });
 }

--- a/jquery.skeduler.js
+++ b/jquery.skeduler.js
@@ -22,6 +22,9 @@
     lineHeight: 30,      // height of one half-hour line in grid
     borderWidth: 1,      // width of board of grid cell
 
+    timelineStart: 0,     //When should the timeline start?
+    timelineStop: 24,     //When should the timeline end?
+
     debug: false
   };
   var settings = {};
@@ -46,7 +49,8 @@
    * startTime - in hours
    */
   function getCardTopPosition(startTime) {
-    return (settings.lineHeight + settings.borderWidth) * (startTime * 2);
+    //return (settings.lineHeight + settings.borderWidth) * (startTime * 2);
+    return ((settings.lineHeight + settings.borderWidth) * (startTime * 2)) - ((settings.lineHeight + settings.borderWidth)*settings.timelineStart*2);
   }
 
   /**
@@ -116,7 +120,7 @@
       );
 
     for (var i = 0; i < args.args.length; i++) {
-      var width = 194 / (args.args[i] || 1);
+      var width = 194 / (+args.args[i] || 1);
 
       tasks[i].width = width;
       tasks[i].left = (args.indexes[i] * width) || 4;
@@ -179,7 +183,7 @@
 
     var gridColumnElement = div.clone();
 
-    for (var i = 0; i < 24; i++) {
+    for (var i = settings.timelineStart; i < settings.timelineStop; i++) {
       // Populate timeline
       div.clone()
         .text(toTimeString(i))


### PR DESCRIPTION
When initializing a Skeduler instance, settings for 'timelineStart' and 'timelineStop' can be specified and that will make the timeline shorter. Could be used i.e. for a dashboard of a business with shorter than 24 hour service. If these are not specified, it automatically defaults to 0 and 24 respectively. See picture below (or updated demo/main.js file) for example.
![image](https://user-images.githubusercontent.com/33516559/123798597-3dbc7680-d8df-11eb-817e-10cf5bc8e37d.png)
